### PR TITLE
stdm: add possibility to get multiple urls for a single build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Display Python version

--- a/bin/symbiflow_get_latest_artifact_url
+++ b/bin/symbiflow_get_latest_artifact_url
@@ -9,6 +9,6 @@
 #
 # SPDX-License-Identifier:	ISC
 
-from stpm import get_latest_artifact_url
+from stdm import get_latest_artifact_url
 
 print(get_latest_artifact_url())

--- a/stdm/__init__.py
+++ b/stdm/__init__.py
@@ -16,10 +16,7 @@ import requests
 
 # For now we use only `symbiflow-arch-defs` and download tarballs
 def get_latest_artifact_url(
-    project="symbiflow-arch-defs",
-    build_name="install",
-    jobset="continuous",
-    get_max_int=False,
+    project="symbiflow-arch-defs", build_name="install", jobset="continuous"
 ):
     # Handle case in which there is build_name is absent
     if build_name:
@@ -50,7 +47,13 @@ def get_latest_artifact_url(
 
         for obj in items:
             obj_int = int(obj["id"].replace(to_strip, "").split("/")[0])
-            urls_of_integers[obj_int] = obj["mediaLink"]
+            if obj_int not in urls_of_integers:
+                urls_of_integers[obj_int] = list()
+
+            artifact_name = obj["selfLink"].split("%2F")[-1]
+            artifact_link = obj["mediaLink"]
+            artifact = {"name": artifact_name, "url": obj["mediaLink"]}
+            urls_of_integers[obj_int].append(artifact)
 
         try:
             params["pageToken"] = r.json()["nextPageToken"]
@@ -63,10 +66,7 @@ def get_latest_artifact_url(
         print(e)
         return ""
 
-    if get_max_int:
-        return urls_of_integers[max_int], max_int
-    else:
-        return urls_of_integers[max_int]
+    return urls_of_integers[max_int], max_int
 
 
 def main():
@@ -90,18 +90,40 @@ def main():
         help="Name of the jobset. Can choose between presubmit and continous",
     )
     parser.add_argument(
-        "--get_max_int",
+        "--get_build_number",
         action="store_true",
-        help="Retrieve also the CI build number",
+        help="Retrieve the CI build number",
+    )
+    parser.add_argument(
+        "--get_single_url",
+        action="store_true",
+        help="Retrieve a single random URL from a given build",
+    )
+    parser.add_argument(
+        "--get_all_urls",
+        action="store_true",
+        help="Retrieve all the URLs of a given build",
     )
 
     args = parser.parse_args()
 
-    print(
-        get_latest_artifact_url(
-            args.project, args.build_name, args.jobset, args.get_max_int
+    if not (args.get_all_urls ^ args.get_single_url ^ args.get_build_number):
+        args.get_single_url = True
+
+    if args.get_build_number:
+        _, build_number = get_latest_artifact_url(
+            args.project, args.build_name, args.jobset
         )
-    )
+        print(build_number)
+
+    elif args.get_all_urls:
+        urls, _ = get_latest_artifact_url(args.project, args.build_name, args.jobset)
+        for url in urls:
+            print(url)
+
+    elif args.get_single_url:
+        urls, _ = get_latest_artifact_url(args.project, args.build_name, args.jobset)
+        print(urls[0]["url"])
 
 
 if __name__ == "__main__":

--- a/stdm/__init__.py
+++ b/stdm/__init__.py
@@ -107,21 +107,25 @@ def main():
 
     args = parser.parse_args()
 
-    if not (args.get_all_urls ^ args.get_single_url ^ args.get_build_number):
+    # Default to use get_single_url if none of the options is selected
+    if not (args.get_all_urls or args.get_single_url or args.get_build_number):
         args.get_single_url = True
 
     if args.get_build_number:
+        assert not (args.get_all_urls or args.get_single_url)
         _, build_number = get_latest_artifact_url(
             args.project, args.build_name, args.jobset
         )
         print(build_number)
 
     elif args.get_all_urls:
+        assert not (args.get_build_number or args.get_single_url)
         urls, _ = get_latest_artifact_url(args.project, args.build_name, args.jobset)
         for url in urls:
             print(url)
 
     elif args.get_single_url:
+        assert not (args.get_build_number or args.get_all_urls)
         urls, _ = get_latest_artifact_url(args.project, args.build_name, args.jobset)
         print(urls[0]["url"])
 

--- a/tests/test_stdm.py
+++ b/tests/test_stdm.py
@@ -10,6 +10,11 @@
 # SPDX-License-Identifier:	ISC
 
 import pytest
+import argparse
+
+parser = argparse.ArgumentParser(
+    description="Retrieves the latest artifacts of SymbiFlow-related CIs."
+)
 
 
 def test_get_symbiflow_arch_defs_tarball():
@@ -17,9 +22,12 @@ def test_get_symbiflow_arch_defs_tarball():
     import requests
     import filetype
 
-    url = get_latest_artifact_url("symbiflow-arch-defs", "install")
+    urls, build_number = get_latest_artifact_url("symbiflow-arch-defs", "install")
 
+    url = urls[0]["url"]
     response = requests.get(url)
     ext = filetype.guess_extension(response.content)
 
     assert "xz" is ext
+    assert urls[0]["name"].endswith("tar.xz")
+    assert isinstance(build_number, int)


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR allows returning different results based on input parameters:

- `--get_build_number`: returns the latest build number
- `--get_all_urls`: returns a list of dictionaries. The dictionary contains also the name of the artifact, so that to correctly name the latest link (e.g. in symbiflow-arch-defs GH actions)

```
{'name': 'symbiflow-arch-defs-install-05bd35c7.tar.xz', 'url': 'https://www.googleapis.com/download/storage/v1/b/symbiflow-arch-defs/o/artifacts%2Fprod%2Ffoss-fpga-tools%2Fsymbiflow-arch-defs%2Fpresubmit%2Finstall%2F1049%2F20201123-030526%2Fsymbiflow-arch-defs-install-05bd35c7.tar.xz?generation=1606156380577163&alt=media'}
{'name': 'symbiflow-xc7a100t_test.tar.xz', 'url': 'https://www.googleapis.com/download/storage/v1/b/symbiflow-arch-defs/o/artifacts%2Fprod%2Ffoss-fpga-tools%2Fsymbiflow-arch-defs%2Fpresubmit%2Finstall%2F1049%2F20201123-030526%2Fsymbiflow-xc7a100t_test.tar.xz?generation=1606156383271653&alt=media'}
```

- `--get_single_url`: returns one URL only (this is enabled by default)

```
https://www.googleapis.com/download/storage/v1/b/symbiflow-arch-defs/o/artifacts%2Fprod%2Ffoss-fpga-tools%2Fsymbiflow-arch-defs%2Fpresubmit%2Finstall%2F1049%2F20201123-030526%2Fsymbiflow-arch-defs-install-05bd35c7.tar.xz?generation=1606156380577163&alt=media
```